### PR TITLE
only one instance of classic should be set

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -53,15 +53,10 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
-      }),
-    ],
-    [
-      '@docusaurus/preset-classic',
-      {
         googleTagManager: {
-          containerId: 'GTM-P7TZQLM',
+          containerId: "GTM-P7TZQLM",
         },
-      },
+      }),
     ],
   ],
 


### PR DESCRIPTION
The server couldn't start or build with the current placement of the google tag.

```
[INFO] Starting the development server...
[ERROR] Error: Plugin "docusaurus-plugin-content-docs" is used 2 times with ID "default".
To use the same plugin multiple times on a Docusaurus site, you need to assign a unique ID to each plugin instance.

The plugin ID is "default" by default. It's possible that the preset you are using already includes a plugin instance, in which case you either want to disable the plugin in the preset (to use a single instance), or assign another ID to your extra plugin instance (to use multiple instances).
    at /Users/kai/code/src/github.com/noteable-io/platform-site/node_modules/@docusaurus/core/lib/server/plugins/pluginIds.js:23:23
    at Array.forEach (<anonymous>)
    at /Users/kai/code/src/github.com/noteable-io/platform-site/node_modules/@docusaurus/core/lib/server/plugins/pluginIds.js:21:45
    at Array.forEach (<anonymous>)
    at ensureUniquePluginInstanceIds (/Users/kai/code/src/github.com/noteable-io/platform-site/node_modules/@docusaurus/core/lib/server/plugins/pluginIds.js:19:35)
    at initPlugins (/Users/kai/code/src/github.com/noteable-io/platform-site/node_modules/@docusaurus/core/lib/server/plugins/init.js:92:51)
    at async loadPlugins (/Users/kai/code/src/github.com/noteable-io/platform-site/node_modules/@docusaurus/core/lib/server/plugins/index.js:26:21)
    at async load (/Users/kai/code/src/github.com/noteable-io/platform-site/node_modules/@docusaurus/core/lib/server/index.js:76:58)
    at async Command.start (/Users/kai/code/src/github.com/noteable-io/platform-site/node_modules/@docusaurus/core/lib/commands/start.js:44:19)
```

Now it starts fine.