### PR TITLE
Fix GitHub Pages Deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,7 @@ jobs:
   deploy:
     # Add a dependency to the build job
     needs: build
-    if: ${{ github.ref == '/refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:


### PR DESCRIPTION
There should not be a leading `/` on `refs/heads/main`