### PR TITLE
clean out overriden metadata

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -67,27 +67,7 @@ const config = {
         respectPrefersColorScheme: true,
       },
       image: "img/noteable-platform-social-card.png",
-      metadata: [
-        {
-          name: "keywords",
-          content: "jupyter, python, llm, chatgpt, developer, blog",
-        },
-        { name: "twitter:site", content: "@noteable_io" },
-        {
-          name: "twitter:description",
-          content:
-            "Resources for developers working with Noteable notebook and LLM functionality",
-        },
-        {
-          name: "og:description",
-          content:
-            "Resources for developers working with Noteable notebook and LLM functionality",
-        },
-        {
-          name: "og:site_name",
-          content: "Noteable",
-        },
-      ],
+      metadata: [{ name: "twitter:site", content: "@noteable_io" }],
       navbar: {
         title: "Noteable Developer Platform",
         logo: {


### PR DESCRIPTION
Setting metadata in the themeconfig was overriding the frontmatter on the blog post. I'm removing it so we can get the nice social media cards on posts.